### PR TITLE
chore: Add contributing guide with relicensing terms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing guide
+
+Thank you for investing your time in contributing to our project. ❤️
+
+This repository is part of the _re·sil·ient_ ecosystem, with the main project being the [**resilient.sile**](https://github.com/Omikhleia/resilient.sile) collection of classes and packages.
+
+We are excited to have you on board and look forward to your contributions. This guide will help you understand how to contribute effectively and what we expect from you.
+
+## License grants for contributions
+
+### License grants for submitted code
+
+By submitting code, you agree to license your contribution under the same license as the project (the GPL-3.0 license), or any other license that is compatible with the GPL-3.0 license. This means that your code will be available for others to use, modify, and distribute under the same terms as the _re·sil·ient_ project itself.
+
+You also agree that the owner(s) and maintainer(s)-in-chief of the _re·sil·ient_ project may relicense, at their sole discretion, any part of the code under the same license as the SILE Typesetter, as long as the latter remains open source, for the purpose of up-streaming patches and features to the SILE project, when they are deemed useful in its larger context. In other words, while _re·sil·ient_ is not dual-licensed, the owner(s) and maintainer(s)-in-chief of the project may choose to relicense your contribution without seeking your permission, for up-streaming purposes only. This is to ensure that the features introduced in _re·sil·ient_ can be made available to the SILE Typesetter project, which is a separate project with its own owners and distributed under a different license (currently the MIT license, uncompatible with the GPL-3.0 license).
+
+The _re·sil·ient_ project owes a lot to the SILE Typesetter project, and on a case-by-case basis, we may choose to relicense components that would be useful to it, and that are not already part of it. This is a way to give back to the SILE community and ensure that the features we develop can benefit a wider audience.
+
+### License grants for submitted documentation
+
+By submitting documentation, you agree to license your contribution under the same license as the project (CC-BY-SA 2.0 or any other license that is compatible with the CC-BY-SA 2.0 license). This means that your documentation will be available for others to use, modify, and distribute under the same terms as the project itself.
+
+By documentation, we mean any text, images, or other content that you submit to the project, including but not limited to README files, user guides, and other in-code documentation content.
+
+## Issues first, Pull Requests later
+
+Always ensure your issue is not already reported before creating a new one. If you find an existing issue that matches your problem, please add any relevant information to that issue instead of creating a new one.
+
+Please refrain from submitting Pull Requests (PRs) before discussing your ideas in the Issues section. This will help us understand your intentions and provide feedback on your proposed changes.
+
+This is especially important for larger changes or new features, as we want to ensure that your work aligns with the project's goals and direction.
+
+## Code style
+
+- Use spaces instead of tabs for indentation.
+- Use 2 spaces for indentation.
+- Write clear and concise comments to explain complex code, and use LDoc-style comments for functions and classes.
+- Follow the existing code style and conventions in the project.
+- When modifying existing code, try to maintain the same style and structure as the surrounding code, and avoid introducing unnecessary changes.


### PR DESCRIPTION
A possible proposal for addressing some of the concerns in #7 and allow me to possibly upstream to SILE anything I want (as long as the latter stays open source, obviously).

Closes #7 